### PR TITLE
Add support for Containers

### DIFF
--- a/src/Torsor/Collections.hs
+++ b/src/Torsor/Collections.hs
@@ -127,8 +127,8 @@ diffDiffableContainer new old =
          in pure $ Shift s
    in lost <> shift <> gain
 
-moveDiffableContainer :: (DiffableContainer f g, Torsor a b) => f a -> ContainerDiff f g a b -> f a
-moveDiffableContainer = foldl' go
+moveDiffableContainer :: (DiffableContainer f g, Torsor a b) => ContainerDiff f g a b -> f a -> f a
+moveDiffableContainer = flip (foldl' go)
   where
     go x (Add n) = patchIn n x
     go x (Drop n) = patchOut n x
@@ -157,7 +157,7 @@ instance (Ord a) => DiffableContainer (M.Map a) ((,) a) where
 
 instance (Ord a, Torsor value diff) => Torsor (M.Map a value) (ContainerDiff (M.Map a) ((,) a) value diff) where
   difference = diffDiffableContainer
-  add = flip moveDiffableContainer
+  add = moveDiffableContainer
 
 instance DiffableContainer IM.IntMap ((,) Int) where
   gains new = IM.foldMapWithKey (curry pure) . IM.difference new
@@ -169,4 +169,4 @@ instance DiffableContainer IM.IntMap ((,) Int) where
 
 instance (Torsor value diff) => Torsor (IM.IntMap value) (ContainerDiff IM.IntMap ((,) Int) value diff) where
   difference = diffDiffableContainer
-  add = flip moveDiffableContainer
+  add = moveDiffableContainer

--- a/src/Torsor/Collections.hs
+++ b/src/Torsor/Collections.hs
@@ -170,3 +170,17 @@ instance DiffableContainer IM.IntMap ((,) Int) where
 instance (Torsor value diff) => Torsor (IM.IntMap value) (ContainerDiff IM.IntMap ((,) Int) value diff) where
   difference = diffDiffableContainer
   add = moveDiffableContainer
+
+instance DiffableContainer S.Seq Identity where
+  gains new old = foldMap (pure . Identity) $ S.drop (S.length old) new
+  losses new old = foldMap (pure . Identity) $ S.drop (S.length new) old
+  remained = S.zip
+  patchIn v vs = vs S.|> runIdentity v
+  patchOut _ vs = case S.viewr vs of
+    S.EmptyR -> vs
+    inner S.:> _ -> inner
+  zipper = S.zipWith
+
+instance (Torsor value diff) => Torsor (S.Seq value) (ContainerDiff S.Seq Identity value diff) where
+  difference = diffDiffableContainer
+  add = moveDiffableContainer

--- a/src/Torsor/Collections.hs
+++ b/src/Torsor/Collections.hs
@@ -1,7 +1,135 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 
 module Torsor.Collections where
 
-import Data.Map
+import Data.Foldable (Foldable (fold), foldl')
+import Data.Functor.Identity (Identity (..))
+import qualified Data.Map as M
+import qualified Data.Sequence as S
 import Torsor
+
+
+data Diff v d = Add v | Drop v | Shift d
+  deriving (Show, Eq)
+
+instance Additive d => Additive [Diff v d] where
+  zero = []
+  invert = reverse . fmap go where
+    go (Add v) = Drop v
+    go (Drop v) = Add v
+    go (Shift v) = Shift $ invert v
+  plus = (<>)
+  minus x y = x `plus` invert y
+
+-- | A typeclass for diffing containers.  This exists entirely to
+-- simplify creating Torsor instances by eliminating boilerplate
+-- between containers.  The `f` type function is our container
+-- (e.g. `Map String`).  The `g` type function annotates the values
+-- which are added and removed from the container.  For example, on
+-- the `IntMap`, `g` is `(Int,)`, as each value added or removed needs
+-- to be annotated with its key.
+class DiffableContainer f g | f -> g where
+  -- | The elements which have been added to the container
+  gains ::
+    (Applicative t, Foldable t, Monoid (t (g a))) =>
+    -- | The new value
+    f a ->
+    -- | The old value
+    f a ->
+    -- | A collection of the new annotated new elements
+    t (g a)
+
+  losses ::
+    (Applicative t, Foldable t, Monoid (t (g a))) =>
+    -- | The new value
+    f a ->
+    -- | The old value
+    f a ->
+    -- | A collection of the elements removed from the old version by the new one
+    t (g a)
+
+  -- | Find the changed values within the container
+  remained ::
+    -- | The new value
+    f a ->
+    -- | The old value
+    f a ->
+    -- | A container with all of the new and old values together.  Values which were added or removed are ignored
+    f (a, a)
+
+  -- | Add an annotated element to the container
+  patchIn ::
+    -- | The annotated element
+    g a ->
+    -- | The original container
+    f a ->
+    -- | The updated container
+    f a
+
+  -- | Drop an element from the container
+  patchOut ::
+    -- | The annotated element
+    g a ->
+    -- | The original container
+    f a ->
+    -- | The updated container
+    f a
+
+  -- | Zip a function over two containers, acting on values present in
+  -- both containers.  Note that it is a zip and *not* the applicative
+  -- instance.
+  zipper :: (a -> b -> c) -> f a -> f b -> f c
+
+
+-- | Build a monadic response to changes in the container
+foldDiffM ::
+  (DiffableContainer f g, Torsor a b, Monoid w, Monad m) =>
+  -- | Response to new elements
+  (g a -> m w) ->
+  -- | Response to lost elements
+  (g a -> m w) ->
+  -- | Response to changed elements
+  (f b -> m w) ->
+  -- | The difference to operate over
+  ContainerDiff f g a b ->
+  m w
+foldDiffM add drp shft = fmap fold . mapM go
+  where
+    go (Add x) = add x
+    go (Drop x) = drp x
+    go (Shift x) = shft x
+
+-- | Build a response to changes in the container
+foldDiff ::
+  (DiffableContainer f g, Torsor a b, Monoid w) =>
+  -- | Response to new elements
+  (g a -> w) ->
+  -- | Response to lost elements
+  (g a -> w) ->
+  -- | Response to changed elements
+  (f b -> w) ->
+  -- | The difference to operate over
+  ContainerDiff f g a b ->
+  w
+foldDiff add drp shft = runIdentity . foldDiffM (Identity . add) (Identity . drp) (Identity . shft)
+
+diffDiffableContainer :: (Functor f, Foldable f, DiffableContainer f g, Torsor a b) => f a -> f a -> ContainerDiff f g a b
+diffDiffableContainer new old =
+  let gain = Add <$> gains new old
+      lost = Drop <$> losses new old
+      shift =
+        let s = uncurry difference <$> remained new old
+         in pure $ Shift s
+   in lost <> shift <> gain
+
+moveDiffableContainer :: (DiffableContainer f g, Torsor a b) => f a -> ContainerDiff f g a b -> f a
+moveDiffableContainer = foldl' go
+  where
+    go x (Add n) = patchIn n x
+    go x (Drop n) = patchOut n x
+    go x (Shift d) = zipper (flip add) x d
+
+-- | The difference for a container.
+type ContainerDiff f g value diff = S.Seq (Diff (g value) (f diff))

--- a/src/Torsor/Collections.hs
+++ b/src/Torsor/Collections.hs
@@ -184,3 +184,18 @@ instance DiffableContainer S.Seq Identity where
 instance (Torsor value diff) => Torsor (S.Seq value) (ContainerDiff S.Seq Identity value diff) where
   difference = diffDiffableContainer
   add = moveDiffableContainer
+
+instance DiffableContainer Maybe Identity where
+  gains (Just x) Nothing = pure $ Identity x
+  gains _ _ = mempty
+  losses Nothing (Just x) = pure $ Identity x
+  losses _ _ = mempty
+  remained (Just x) (Just y) = Just (x, y)
+  remained _ _ = Nothing
+  patchIn (Identity x) _ = Just x
+  patchOut _ _ = Nothing
+  zipper f a b = f <$> a <*> b
+
+instance (Torsor value diff) => Torsor (Maybe value) (ContainerDiff Maybe Identity value diff) where
+  difference = diffDiffableContainer
+  add = moveDiffableContainer

--- a/src/Torsor/Collections.hs
+++ b/src/Torsor/Collections.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
+
+module Torsor.Collections where
+
+import Data.Map
+import Torsor

--- a/src/Torsor/Containers.hs
+++ b/src/Torsor/Containers.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Torsor.Collections (DiffableContainer(..), foldDiff, foldDiffM, ContainerDiff, differenceDiffableContainer, addDiffableContainer) where
+module Torsor.Containers (DiffableContainer(..), foldDiff, foldDiffM, ContainerDiff, differenceDiffableContainer, addDiffableContainer) where
 
 import Data.Foldable (Foldable (fold), foldl')
 import Data.Functor.Identity (Identity (..))

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -17,7 +17,7 @@ tests = testGroup "Tests" [differenceableTests]
 
 differenceableTests :: TestTree
 -- differenceableTests = testGroup "Diffable" [intTests, floatTests, doubleTests, sumTests, mapTests, intMapTests, sequenceTests, maybeTests]
-differenceableTests = testGroup "Torsor" [intTests, mapTests]
+differenceableTests = testGroup "Torsor" [intTests, mapTests, intMapTests]
 
 intTests :: TestTree
 intTests =
@@ -63,13 +63,13 @@ mapTests =
       QC.testProperty "Path Law" $ \old middle new -> add (difference middle old <> difference new middle) old == (new :: M.Map Int Int)
     ]
 
--- intMapTests :: TestTree
--- intMapTests =
---   testGroup
---     "IntMaps"
---     [ QC.testProperty "Add law" $ \new old -> add old (difference new old) == (new :: IM.IntMap (Sum Int)),
---       QC.testProperty "Path Law" $ \old middle new -> add old (difference middle old <> difference new middle) == (new :: IM.IntMap (Sum Int))
---     ]
+intMapTests :: TestTree
+intMapTests =
+  testGroup
+    "IntMaps"
+    [ QC.testProperty "Add law" $ \new old -> add (difference new old) old == (new :: IM.IntMap Int),
+      QC.testProperty "Path Law" $ \old middle new -> add (difference middle old <> difference new middle) old == (new :: IM.IntMap Int)
+    ]
 
 -- sequenceTests :: TestTree
 -- sequenceTests =

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -17,7 +17,7 @@ tests = testGroup "Tests" [differenceableTests]
 
 differenceableTests :: TestTree
 -- differenceableTests = testGroup "Diffable" [intTests, floatTests, doubleTests, sumTests, mapTests, intMapTests, sequenceTests, maybeTests]
-differenceableTests = testGroup "Torsor" [intTests, mapTests, intMapTests]
+differenceableTests = testGroup "Torsor" [intTests, mapTests, intMapTests, sequenceTests]
 
 intTests :: TestTree
 intTests =
@@ -27,33 +27,6 @@ intTests =
       QC.testProperty "Add law" $ \new old -> add old (difference new old) == (new :: Int),
       QC.testProperty "Path Law" $ \old middle new -> add old (difference middle old + difference new middle) == (new :: Int)
     ]
-
--- floatTests :: TestTree
--- floatTests =
---   testGroup
---     "Floats"
---     [ QC.testProperty "Difference law" $ \path (old :: Float) -> difference (add old path) old `eqDouble` path,
---       QC.testProperty "Add law" $ \new old -> add old (difference new old) `eqDouble` (new :: Float),
---       QC.testProperty "Path Law" $ \old middle new -> add old (difference middle old + difference new middle) `eqDouble` (new :: Float)
---     ]
-
--- doubleTests :: TestTree
--- doubleTests =
---   testGroup
---     "Doubles"
---     [ QC.testProperty "Difference law" $ \path (old :: Double) -> difference (add old path) old `eqDouble` path,
---       QC.testProperty "Add law" $ \new old -> add old (difference new old) `eqDouble` (new :: Double),
---       QC.testProperty "Path Law" $ \old middle new -> add old (difference middle old + difference new middle) `eqDouble` (new :: Double)
---     ]
-
--- sumTests :: TestTree
--- sumTests =
---   testGroup
---     "Sums"
---     [ QC.testProperty "Difference law" $ \path (old :: Sum Int) -> difference (add old path) old == path,
---       QC.testProperty "Add law" $ \new old -> add old (difference new old) == (new :: Sum Int),
---       QC.testProperty "Path Law" $ \old middle new -> add old (difference middle old <> difference new middle) == (new :: Sum Int)
---     ]
 
 mapTests :: TestTree
 mapTests =
@@ -71,13 +44,13 @@ intMapTests =
       QC.testProperty "Path Law" $ \old middle new -> add (difference middle old <> difference new middle) old == (new :: IM.IntMap Int)
     ]
 
--- sequenceTests :: TestTree
--- sequenceTests =
---   testGroup
---     "Sequences"
---     [ QC.testProperty "Add law" $ \new old -> add old (difference new old) == (new :: S.Seq (Sum Int)),
---       QC.testProperty "Path Law" $ \old middle new -> add old (difference middle old <> difference new middle) == (new :: S.Seq (Sum Int))
---     ]
+sequenceTests :: TestTree
+sequenceTests =
+  testGroup
+    "Sequences"
+    [ QC.testProperty "Add law" $ \new old -> add (difference new old) old == (new :: S.Seq Int),
+      QC.testProperty "Path Law" $ \old middle new -> add (difference middle old <> difference new middle) old == (new :: S.Seq Int)
+    ]
 
 -- maybeTests :: TestTree
 -- maybeTests =

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -5,7 +5,7 @@ import qualified Data.Map as M
 import Data.Monoid
 import qualified Data.Sequence as S
 import Torsor
-import Torsor.Collections
+import Torsor.Containers
 import Test.Tasty
 import Test.Tasty.QuickCheck as QC
 

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -16,8 +16,7 @@ tests :: TestTree
 tests = testGroup "Tests" [differenceableTests]
 
 differenceableTests :: TestTree
--- differenceableTests = testGroup "Diffable" [intTests, floatTests, doubleTests, sumTests, mapTests, intMapTests, sequenceTests, maybeTests]
-differenceableTests = testGroup "Torsor" [intTests, mapTests, intMapTests, sequenceTests]
+differenceableTests = testGroup "Torsor" [intTests, mapTests, intMapTests, sequenceTests, maybeTests]
 
 intTests :: TestTree
 intTests =
@@ -52,13 +51,13 @@ sequenceTests =
       QC.testProperty "Path Law" $ \old middle new -> add (difference middle old <> difference new middle) old == (new :: S.Seq Int)
     ]
 
--- maybeTests :: TestTree
--- maybeTests =
---   testGroup
---     "Maybe"
---     [ QC.testProperty "Add law" $ \new old -> add old (difference new old) == (new :: Maybe (Sum Int)),
---       QC.testProperty "Path Law" $ \old middle new -> add old (difference middle old <> difference new middle) == (new :: Maybe (Sum Int))
---     ]
+maybeTests :: TestTree
+maybeTests =
+  testGroup
+    "Maybe"
+    [ QC.testProperty "Add law" $ \new old -> add (difference new old) old == (new :: Maybe Int),
+      QC.testProperty "Path Law" $ \old middle new -> add (difference middle old <> difference new middle) old == (new :: Maybe Int)
+    ]
 
 eqDouble :: (Ord a, Fractional a) => a -> a -> Bool
 eqDouble 0 b = b == 0

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+import qualified Data.IntMap as IM
+import qualified Data.Map as M
+import Data.Monoid
+import qualified Data.Sequence as S
+import Torsor
+import Torsor.Collections
+import Test.Tasty
+import Test.Tasty.QuickCheck as QC
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Tests" [differenceableTests]
+
+differenceableTests :: TestTree
+-- differenceableTests = testGroup "Diffable" [intTests, floatTests, doubleTests, sumTests, mapTests, intMapTests, sequenceTests, maybeTests]
+differenceableTests = testGroup "Torsor" [intTests, mapTests]
+
+intTests :: TestTree
+intTests =
+  testGroup
+    "Ints"
+    [ QC.testProperty "Difference law" $ \path (old :: Int) -> difference (add old path) old == path,
+      QC.testProperty "Add law" $ \new old -> add old (difference new old) == (new :: Int),
+      QC.testProperty "Path Law" $ \old middle new -> add old (difference middle old + difference new middle) == (new :: Int)
+    ]
+
+-- floatTests :: TestTree
+-- floatTests =
+--   testGroup
+--     "Floats"
+--     [ QC.testProperty "Difference law" $ \path (old :: Float) -> difference (add old path) old `eqDouble` path,
+--       QC.testProperty "Add law" $ \new old -> add old (difference new old) `eqDouble` (new :: Float),
+--       QC.testProperty "Path Law" $ \old middle new -> add old (difference middle old + difference new middle) `eqDouble` (new :: Float)
+--     ]
+
+-- doubleTests :: TestTree
+-- doubleTests =
+--   testGroup
+--     "Doubles"
+--     [ QC.testProperty "Difference law" $ \path (old :: Double) -> difference (add old path) old `eqDouble` path,
+--       QC.testProperty "Add law" $ \new old -> add old (difference new old) `eqDouble` (new :: Double),
+--       QC.testProperty "Path Law" $ \old middle new -> add old (difference middle old + difference new middle) `eqDouble` (new :: Double)
+--     ]
+
+-- sumTests :: TestTree
+-- sumTests =
+--   testGroup
+--     "Sums"
+--     [ QC.testProperty "Difference law" $ \path (old :: Sum Int) -> difference (add old path) old == path,
+--       QC.testProperty "Add law" $ \new old -> add old (difference new old) == (new :: Sum Int),
+--       QC.testProperty "Path Law" $ \old middle new -> add old (difference middle old <> difference new middle) == (new :: Sum Int)
+--     ]
+
+mapTests :: TestTree
+mapTests =
+  testGroup
+    "Maps"
+    [ QC.testProperty "Add law" $ \new old -> add (difference new old) old == (new :: M.Map Int Int),
+      QC.testProperty "Path Law" $ \old middle new -> add (difference middle old <> difference new middle) old == (new :: M.Map Int Int)
+    ]
+
+-- intMapTests :: TestTree
+-- intMapTests =
+--   testGroup
+--     "IntMaps"
+--     [ QC.testProperty "Add law" $ \new old -> add old (difference new old) == (new :: IM.IntMap (Sum Int)),
+--       QC.testProperty "Path Law" $ \old middle new -> add old (difference middle old <> difference new middle) == (new :: IM.IntMap (Sum Int))
+--     ]
+
+-- sequenceTests :: TestTree
+-- sequenceTests =
+--   testGroup
+--     "Sequences"
+--     [ QC.testProperty "Add law" $ \new old -> add old (difference new old) == (new :: S.Seq (Sum Int)),
+--       QC.testProperty "Path Law" $ \old middle new -> add old (difference middle old <> difference new middle) == (new :: S.Seq (Sum Int))
+--     ]
+
+-- maybeTests :: TestTree
+-- maybeTests =
+--   testGroup
+--     "Maybe"
+--     [ QC.testProperty "Add law" $ \new old -> add old (difference new old) == (new :: Maybe (Sum Int)),
+--       QC.testProperty "Path Law" $ \old middle new -> add old (difference middle old <> difference new middle) == (new :: Maybe (Sum Int))
+--     ]
+
+eqDouble :: (Ord a, Fractional a) => a -> a -> Bool
+eqDouble 0 b = b == 0
+eqDouble a b = (a - b) / a - 1 < 1e-7

--- a/torsor.cabal
+++ b/torsor.cabal
@@ -15,8 +15,10 @@ cabal-version: >=1.10
 
 library
   hs-source-dirs: src
-  exposed-modules: Torsor
+  exposed-modules: Torsor,
+                   Torsor.Collections
   build-depends: base >= 4.7 && < 5
+               , containers
   default-language: Haskell2010
 
 source-repository head

--- a/torsor.cabal
+++ b/torsor.cabal
@@ -16,7 +16,7 @@ cabal-version: >=1.10
 library
   hs-source-dirs: src
   exposed-modules: Torsor,
-                   Torsor.Collections
+                   Torsor.Containers
   build-depends: base >= 4.7 && < 5
                , containers
   default-language: Haskell2010

--- a/torsor.cabal
+++ b/torsor.cabal
@@ -1,5 +1,5 @@
 name: torsor
-version: 0.1
+version: 0.1.1
 synopsis: Torsor Typeclass
 description: Torsor Typeclass
 homepage: https://github.com/andrewthad/torsor#readme

--- a/torsor.cabal
+++ b/torsor.cabal
@@ -24,3 +24,22 @@ library
 source-repository head
   type: git
   location: https://github.com/andrewthad/torsor
+
+
+test-suite test
+    -- The interface type and version of the test suite.
+    type:             exitcode-stdio-1.0
+
+    -- Directories containing source files.
+    hs-source-dirs:   test
+
+    -- The entrypoint to the test suite.
+    main-is:          Tests.hs
+
+    -- Test dependencies.
+    build-depends: base >= 4.7 && < 5
+                    , torsor
+                    , tasty
+                    , tasty-hspec
+                    , tasty-quickcheck
+                    , containers


### PR DESCRIPTION
This PR adds support for most of the containers in the `containers` library.  Since `containers` is distributed with GHC, I was hoping it wouldn't be a particularly onerous dependency.  I've used this in production and it does properly handle nested structures (eq. `Map a (Map b (Map c value))`).  I've also included some tests to checking these implementations.  The tests do included extra dependencies, but those shouldn't be needed for the base library.

There's a couple of bits I can already see being issues:

1) I left the `Torsor` module as is an simply added my own module for the collections.  It might be better to make a basic `Torsor.Types` module that `Torsor.Containers` can import and have `Torsor` export both.  This would remove the need to the user to explicitly import `Torsor.Containers` to get the orphan container instances.

2) I'm not great at naming things, so some of the types or function may need new names

3) I have intentionally *not* included an implementation for the list type, since diffing will always hang on an infinite list.  That's also the reason that the `ContainerDiff` type uses a Seq - to enforce that the list is finite.  However, using lists may be more performant for our use case.   Also, lists are a fairly common data structure and I don't believe that any developer would be surprised that they couldn't find the difference between two infinte lists and would not consider this a *bug*.

4) I've bumped the version number up to 0.1.1, since everything is backward compatible, but I could also understand this being version 0.2

5)  There is no instance for `Tree` or `Either` at the moment.  These will hopefully come into a future PR, but they're non-trivial.